### PR TITLE
Add docker support and -no-chdir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM golang:1.11-alpine as builder
+
+RUN apk add --no-cache \
+        build-base \
+        git && \
+    go get github.com/gorilla/websocket && \
+    go get golang.org/x/crypto/sha3 && \
+    go get github.com/mattn/go-sqlite3 && \
+    go get github.com/gin-gonic/gin
+
+COPY . /tmp/livedl
+
+RUN cd /tmp/livedl && \
+    go build src/livedl.go
+
+
+
+FROM alpine:3.8 
+
+RUN apk add --no-cache \
+        ca-certificates \
+        ffmpeg \
+        openssl
+
+COPY --from=builder /tmp/livedl/livedl /usr/local/bin/
+
+WORKDIR /livedl
+
+VOLUME /livedl
+
+CMD livedl
+

--- a/Readme.md
+++ b/Readme.md
@@ -106,10 +106,33 @@ set-item env:CGO_ENABLED -value 1
 go build -o livedl.x86.exe src/livedl.go
 ```
 
-## 32bit環境で`x509: certificate signed by unknown authority`が出る
+### 32bit環境で`x509: certificate signed by unknown authority`が出る
 
 動けばいいのであればオプションで以下を指定する。
 
 `-http-skip-verify=on`
+
+## Dockerでビルド
+
+### livedlのソースを取得
+```
+git clone https://github.com/himananiito/livedl.git
+cd livedl
+git checkout master # Or another version that supports docker (contains Dockerfile)
+```
+
+### イメージ作成
+```
+docker build -t <your_image_tag> .
+```
+
+### イメージの使い方
+
+- 出力フォルダを/livedlにマウント
+- 通常のパラメーターに加えて`--no-chdir`を渡す
+
+```
+docker run -it --rm -v ~/livedl:/livedl <your_image_tag> livedl --no-chdir <other_parameters> ...
+```
 
 以上

--- a/src/livedl.go
+++ b/src/livedl.go
@@ -43,13 +43,17 @@ func main() {
 		}
 		baseDir = filepath.Dir(pa)
 	}
-	fmt.Printf("chdir: %s\n", baseDir)
-	if e := os.Chdir(baseDir); e != nil {
-		fmt.Println(e)
-		return
-	}
 
 	opt := options.ParseArgs()
+
+	// chdir if not disabled
+	if !opt.NoChdir {
+		fmt.Printf("chdir: %s\n", baseDir)
+		if e := os.Chdir(baseDir); e != nil {
+			fmt.Println(e)
+			return
+		}
+	}
 
 	// http
 	if opt.HttpRootCA != "" {

--- a/src/options/options.go
+++ b/src/options/options.go
@@ -59,6 +59,7 @@ type Option struct {
 	HttpRootCA             string
 	HttpSkipVerify         bool
 	HttpProxy              string
+	NoChdir                bool
 }
 
 func getCmd() (cmd string) {
@@ -93,10 +94,11 @@ COMMAND:
   -d2m     録画済みのdb(.sqlite3)をmp4に変換する(-db-to-mp4)
 
 オプション/option:
-  -h     ヘルプを表示
-  -vh    全てのオプションを表示
-  -v     バージョンを表示
-  --     後にオプションが無いことを指定
+  -h         ヘルプを表示
+  -vh        全てのオプションを表示
+  -v         バージョンを表示
+  -no-chdir  起動する時chdirしない
+  --         後にオプションが無いことを指定
 
 ニコニコ生放送録画用オプション:
   -nico-login <id>,<password>    (+) ニコニコのIDとパスワードを指定する
@@ -956,6 +958,10 @@ func ParseArgs() (opt Option) {
 				str = "http://" + str
 			}
 			opt.HttpProxy = str
+			return
+		}},
+		Parser{regexp.MustCompile(`\A(?i)--?no-?chdir\z`), func() (err error) {
+			opt.NoChdir = true
 			return
 		}},
 	}


### PR DESCRIPTION
Add docker support. Now people with docker environments can build livedl with extreme ease. The end result is a roughly 80MB- image and does not require any alteration to the host environment.

Also add a command line option `--no-chdir` to suppress `chdir`ing to where livedl binary is located. This may not always be the desired behaviour, for example if you install livedl binary into /usr/local/bin, `chdir`ing towards it will result in either files getting written to a global directory, or nothing get written at all if you don't run livedl with root privilege. This is necessary for using livedl inside docker, because you cannot put image files in a docker volume, and you do not want to write large files to the container filesystem, which hurts performance. And it comes handy when you just want to output to some path other than where the livedl binary lives.
