### PR TITLE
Youtube録画＆コメント修正

### DIFF
--- a/src/youtube/comment.go
+++ b/src/youtube/comment.go
@@ -117,7 +117,17 @@ func getComment(gm *gorman.GoroutineManager, ctx context.Context, sig <-chan str
 					if (! ok) {
 						continue
 					}
-					message, _ := objs.FindString(liveChatMessageRenderer, "message", "simpleText")
+					message, ok := objs.FindString(liveChatMessageRenderer, "message", "simpleText")
+					if (! ok) {
+						message = ""
+						if runs, ok := objs.FindArray(liveChatMessageRenderer, "message", "runs"); ok {
+							//objs.PrintAsJson(runs)
+							for _, r := range runs {
+								mm , _ := objs.FindString(r, "text")
+								message += mm;
+							}
+						}
+					}
 					timestampUsec, ok := objs.FindString(liveChatMessageRenderer, "timestampUsec")
 					if (! ok) {
 						continue

--- a/src/youtube/youtube.go
+++ b/src/youtube/youtube.go
@@ -126,7 +126,13 @@ func getInfo(buff []byte) (title, ucid, author string, err error) {
 
 	//objs.PrintAsJson(data); return
 
-	title, ok := objs.FindString(data, "args", "title")
+	var player_response interface{}
+	err = json.Unmarshal([]byte(data.(map[string]interface{})["args"].(map[string]interface{})["player_response"].(string)), &player_response)
+	if err != nil {
+		err = fmt.Errorf("player_response parse error")
+		return
+	}
+	title, ok := objs.FindString(player_response, "videoDetails", "title")
 	if (! ok) {
 		err = fmt.Errorf("title not found")
 		return


### PR DESCRIPTION
・2019/6/27以降にYoutubeライブのコメントが取得できなくなったのを修正
・2019/7末以降にYoutubeライブのtitleが取得できずに録画できなくなったのを修正

githubにもgoにもいまだに不慣れなのですが、需要がありそうなんでプルリクエスト出してみます。
